### PR TITLE
Various minor fixes

### DIFF
--- a/docs/the-guide/chapter-1-run-a-simple-ml-experiment/index.md
+++ b/docs/the-guide/chapter-1-run-a-simple-ml-experiment/index.md
@@ -99,7 +99,7 @@ The following table describes the files present in the codebase.
 
 ### Download and set up the dataset
 
-Your colleague provide you the following URL to download an archive containing
+Your colleague provided you the following URL to download an archive containing
 the dataset for this machine learning experiment.
 
 ```sh title="Execute the following command(s) in a terminal"
@@ -107,7 +107,7 @@ the dataset for this machine learning experiment.
 wget https://github.com/csia-pme/a-guide-to-mlops/archive/refs/heads/data.zip -O data.zip
 ```
 
-This archive must decompresed and its contents must be moved in the
+This archive must be decompressed and its contents be moved in the
  `data` directory in the working directory of the experiment.
 
 ```sh title="Execute the following command(s) in a terminal"
@@ -232,6 +232,7 @@ Your working directory should now be similar to this:
 5. This is new.
 
 Here, the following should be noted:
+
 - the `prepare.py` script created the `data/prepared` directory and splitted the
   dataset into a training set and a test set
 - the `featurization.py` script created the `data/features` directory and
@@ -273,7 +274,7 @@ You can now safely continue to the next chapter.
 - ❌ Changes to model are not easily visualized
 - ❌ Experiment may not be reproducible on other machines
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and
@@ -282,7 +283,7 @@ collaboration. Continue the guide to learn how.
 ## Sources
 
 Highly inspired by the [_Get Started: Data Pipelines_ -
-dvc.org](https://dvc.org/doc/start/data-management/pipelines) guide.
+dvc.org](https://dvc.org/doc/start/data-management/data-pipelines) guide.
 
 Want to see what the result at the end of this chapter should look like? Have a
 look at the Git repository directory here:

--- a/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/index.md
+++ b/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/index.md
@@ -203,7 +203,7 @@ You can now safely continue to the next chapter.
 - ❌ Changes to model are not easily visualized
 - ❌ Experiment may not be reproducible on other machines
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -7,7 +7,7 @@ experiment data is not.
 
 The goal of this chapter is to store the data of the experiment in a version control system.
 Git is not suitable for this purpose because of its size limitations.
-Git lfs is a solution to this problem, but it is not as efficient as other version control systems.
+Git LFS is a solution to this problem, but it is not as efficient as other version control systems.
 
 [DVC](../../get-started/the-tools-used-in-this-guide#dvc) is a version control system for data.
 It uses chunking to store large files efficiently and track their changes.
@@ -27,8 +27,8 @@ In this chapter, you will learn how to:
 2. Install Google Cloud CLI
 3. Create the Google Storage Bucket
 4. Install DVC
-5. Initialize and configuring DVC
-6. Update the gitignore file and adding the experiment data to DVC
+5. Initialize and configure DVC
+6. Update the `.gitignore` file and add the experiment data to DVC
 7. Push the data files to DVC
 8. Push the metadata files to Git
 
@@ -40,7 +40,7 @@ Let's get started!
 
 Create a Google Cloud Project by going to the [Google Cloud
 console](https://console.cloud.google.com/), select **Select a project** in the
-upper right corner of the screen and select **New project**.
+upper left corner of the screen and select **New project**.
 
 Name your project and select **Create** to create the project.
 
@@ -48,7 +48,7 @@ A new page opens. Note the ID of your project, it will be used later.
 
 !!! warning
 
-	Always make sure you're in the right project by selecting your project with **Select a project** in the upper right corner of the screen.
+	Always make sure you're in the right project by selecting your project with **Select a project** in the upper left corner of the screen.
 
 ### Install Google Cloud CLI
 
@@ -162,7 +162,7 @@ dvc remote add -d data gs://<my bucket name>/dvcstore
 The effect of the `dvc init` command is to create a `.dvc` directory in the
 working directory. This directory contains the configuration of DVC.
 
-### Update the gitignore file and add the experiment data to DVC
+### Update the .gitignore file and add the experiment data to DVC
 
 Now that DVC has been setup, you can add files to DVC.
 
@@ -240,9 +240,9 @@ used by DVC to download and check the integrity of the files. The `.gitignore`
 file is created to add the `data.xml` file to be ignored by Git. The `.dvc`
 files must be added to Git.
 
-Various DVC commands will automatically try to update the gitignore files. If a
+Various DVC commands will automatically try to update the `.gitignore` files. If a
 `.gitignore` file is already present, it will be updated to include the newly
-ignored files. You might need to update existing gitignore files accordingly. 
+ignored files. You might need to update existing `.gitignore` files accordingly.
 
 ### Push the data files to DVC
 
@@ -309,7 +309,7 @@ In this chapter, you have successfully:
 3. Created the Google Storage Bucket
 4. Installed DVC
 5. Initialized and configuring DVC
-6. Updated the gitignore file and adding the experiment data to DVC
+6. Updated the `.gitignore` file and adding the experiment data to DVC
 7. Pushed the data files to DVC
 8. Pushed the metadata files to Git
 
@@ -318,7 +318,7 @@ You fixed some of the previous issues:
 - ✅ Data no longer needs manual download and is placed in the right directory.
 
 When used by another member of the team, they can easily get a copy of the
-experiment data from DVC with the following commands.
+experiment data from DVC with the following command.
 
 ```sh title="Execute the following command(s) in a terminal"
 # Download experiment data from DVC
@@ -336,7 +336,7 @@ You can now safely continue to the next chapter.
 - ❌ Changes to model are not easily visualized
 - ❌ Experiment may not be reproducible on other machines
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and

--- a/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
+++ b/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
@@ -14,7 +14,7 @@ makes it easy to reproduce the experiment and track the effects of changes.
 
 In this chapter, you will learn how to:
 
-1. Remove custom rules from the gitignore file
+1. Remove custom rules from the `.gitignore` file
 2. Set up four DVC pipeline stages:
     - `prepare`
     - `featurize`
@@ -44,7 +44,7 @@ Let's get started!
 
 ## Steps
 
-### Remove custom rules from the gitignore file
+### Remove custom rules from the .gitignore file
 
 As seen in the previous chapter, DVC can update `.gitignore` files.
 
@@ -117,6 +117,7 @@ This stage will be added to the `dvc.yaml` file that describes the pipeline.
 This file can also be edited manually.
 
 The `dvc stage add` accepts some options:
+
 - `-n` specifies the name of the stage
 - `-p` specifies the parameters of the stage (referenced in the `params.yaml` file)
 - `-d` specifies the dependencies of the stage
@@ -371,7 +372,7 @@ Congrats! You have defined a pipeline and know how to reproduce your experiment.
 
 In this chapter, you have successfully:
 
-1. Removed custom rules from the gitignore file
+1. Removed custom rules from the `.gitignore` file
 2. Set up four DVC pipeline stages
     - `prepare`
     - `featurize`
@@ -411,7 +412,7 @@ You can now safely continue to the next chapter.
 - ❌ Changes to model are not easily visualized
 - ❌ Experiment may not be reproducible on other machines
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and
@@ -420,7 +421,7 @@ collaboration. Continue the guide to learn how.
 ## Sources
 
 Highly inspired by the [_Get Started: Data Pipelines_ -
-dvc.org](https://dvc.org/doc/start/data-management/pipelines) guide.
+dvc.org](https://dvc.org/doc/start/data-management/data-pipelines) guide.
 
 Want to see what the result at the end of this chapter should look like? Have a
 look at the Git repository directory here:

--- a/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/index.md
+++ b/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/index.md
@@ -5,9 +5,9 @@
 In the previous chapter, you did set up a DVC pipeline to reproduce your
 experiment.
 
-Once this stage is created, you'll be able to change our model's configruation,
-evaluate the new configuration and compare it's performance with the last
-commited ones. 
+Once this stage is created, you'll be able to change our model's configuration,
+evaluate the new configuration and compare its performance with the last
+commited ones.
 
 In this chapter, you will learn how to:
 
@@ -274,7 +274,7 @@ You can now safely continue to the next chapter.
   plots to identify differences between iterations
 - ❌ Experiment may not be reproducible on other machines
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and

--- a/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/index.md
+++ b/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/index.md
@@ -5,7 +5,7 @@
 At this point, your code, your data and your execution process should be
 shared with Git and DVC.
 
-One of great advantages of using a DVC pipeline is the ability to reproduce the
+One of the great advantages of using a DVC pipeline is the ability to reproduce the
 experiment. You will now add a CI/CD pipeline to execute the ML experiment
 remotely. This will prevent changes to break the pipeline and to avoid the "but it works on
 my machine" effect.
@@ -96,7 +96,7 @@ Please refer to the correct instructions based on your Git repository provider.
 	Store the output as a CI/CD variable by going to the **Settings** section from
 	the top header of your GitHub repository.
 
-	Select **Secrets > Actions** and select **New repository secret**.
+	Select **Secrets and variables > Actions** and select **New repository secret**.
 
 	Create a new variable named `GCP_SERVICE_ACCOUNT_KEY` with the output value of
 	the Google Service Account key file as its value. Save the variable by selecting
@@ -296,7 +296,7 @@ You can now safely continue to the next chapter.
 - ✅ The experiment can be executed on a clean machine with the help of a CI/CD
   pipeline
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 You will address these issues in the next chapters for improved efficiency and

--- a/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/index.md
+++ b/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/index.md
@@ -12,15 +12,15 @@ In this chapter, you will learn how to:
 2. Push the updated CI/CD configuration file to Git
 3. Open an issue in your issue tracker
 4. Create a new branch to add your changes
-5. Check out to the new branch
-6. Commit and pushing the changes that were not commited in [Chapter 5: Track
+5. Check out the new branch
+6. Commit and push the changes that were not commited in [Chapter 5: Track
    model evolutions with
    DVC](../chapter-5-track-model-evolutions-with-dvc)
 7. Create a pull request/merge request
 8. Visualize the execution of the CI/CD pipeline
-9. Visualizie the CML report that is added to your pull request/merge request
+9. Visualize the CML report that is added to your pull request/merge request
 10. Merge the pull request/merge request to the main branch
-11. Switch back to the main branch and pulling latest changes
+11. Switch back to the main branch and pull latest changes
 
 !!! info
 
@@ -646,7 +646,7 @@ DVC](../chapter-5-track-model-evolutions-with-dvc)?
 
 You can now commit them to trigger a change on the remote repository.
 
-If you don't have changes in your working directory, just update the paramerters
+If you don't have changes in your working directory, just update the parameters
 of the experiment in `params.yaml` and reproduce the experiment with `dvc
 repro`. You can then commit the changes.
 
@@ -806,7 +806,7 @@ In this chapter, you have successfully:
 2. Pushed the updated CI/CD configuration file to Git
 3. Opened an issue in your issue tracker
 4. Created a new branch to add your changes
-5. Checked out to the new branch
+5. Checked out the new branch
 6. Commit and pushed the changes that were not commited in [Chapter 5: Track
    model evolutions with
    DVC](../chapter-5-track-model-evolutions-with-dvc)
@@ -835,7 +835,7 @@ You can now safely continue to the next chapter.
 - ✅ The experiment can be executed on a clean machine with the help of a CI/CD
   pipeline and CML
 - ❌ Model may have required artifacts that are forgotten or omitted in
-  saved/loadedstate and there is no easy way to use the model outside of the
+  saved/loaded state and there is no easy way to use the model outside of the
   experiment context
 
 ## Sources

--- a/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
+++ b/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
@@ -775,8 +775,8 @@ journey and the next things you could do with your model.
   plots to identify differences between iterations
 - ✅ The experiment can be executed on a clean machine with the help of a CI/CD
   pipeline and CML
-- ✅ The model can be saved and loaded with all have required artifacts for
-  future usage and the model can be served outside of the experiment context.
+- ✅ The model can be saved and loaded with all required artifacts for future
+  usage and the model can be served outside of the experiment context.
 
 ## Sources
 


### PR DESCRIPTION
* Fixed broken link in sources
* Fixed the Select Project location in GCloud console
* Fixed list not displayed correctly Markdown needs an empty line before a list.
* Fixed various typos
* Updated GitHub instructions for secrets
* Adjusted .gitignore references for consistency