### PR TITLE
16 minor improvements

### DIFF
--- a/docs/advanced-concepts/train-the-model-on-a-kubernetes-cluster-with-cml/.gitignore
+++ b/docs/advanced-concepts/train-the-model-on-a-kubernetes-cluster-with-cml/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-1-run-a-simple-ml-experiment/index.md
+++ b/docs/the-guide/chapter-1-run-a-simple-ml-experiment/index.md
@@ -97,6 +97,10 @@ The following table describes the files present in the codebase.
 | `src/evaluate.py`      | Evaluate the ML model using DVC                  | The model to evaluate                 | The results of the model evaluation in `evaluation` directory |
 | `params.yaml`          | The parameters to run the ML experiment          | -                                     | -                                                             |
 
+!!! info
+    The `params.yaml` is the default file used by DVC. You can find the reference here: <https://dvc.org/doc/command-reference/params>.
+
+
 ### Download and set up the dataset
 
 Your colleague provided you the following URL to download an archive containing

--- a/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/.gitignore
+++ b/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 # Data used to train the models
 data
 

--- a/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/index.md
+++ b/docs/the-guide/chapter-2-share-your-ml-experiment-code-with-git/index.md
@@ -95,7 +95,10 @@ Additionally, this will help to ensure that the repository size and clone time
 remain optimized.
 
 
-```sh title="Execute the following command(s) in a terminal"
+```sh title=".gitignore"
+## Macos Specific
+.DS_Store
+
 # Data used to train the models
 data
 

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/.gitignore
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 # Data used to train the models
 data/features
 data/prepared

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -188,7 +188,10 @@ the `data` directory. However, you still don't want the directories
 Update the `.gitignore` file by changing `data` to `data/features` and
 `data/prepared`.
 
-```sh title="Execute the following command(s) in a terminal" hl_lines="2-3"
+```sh title=".gitignore" hl_lines="5-6"
+## Macos Specific
+.DS_Store
+
 # Data used to train the models
 data/features
 data/prepared

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -96,9 +96,11 @@ To be able to create the bucket, the project must be linked to an active billing
 
 Create the Google Storage Bucket to store the data with the Google Cloud CLI. You should ideally select a location close to where most of the expected traffic will come from. You can view the available regions at [Cloud locations](https://cloud.google.com/about/locations).
 
+Change the `<my bucket name>` to your own bucket name (ex: `mlopsdemo`).
+
 !!! warning
 
-	The bucket name must be unique accross all Google Cloud projects and users. Change the `<my bucket name>` to your own bucket name.
+	The bucket name must be unique accross all Google Cloud projects and users.
 
 ```sh title="Execute the following command(s) in a terminal"
 gcloud storage buckets create gs://<my bucket name> \

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -79,7 +79,11 @@ gcloud projects list
 
 # Select your Google Cloud project
 gcloud config set project <id of your gcp project>
+```
 
+Then run the following command to authenticate to Google Cloud with the Application Default.
+
+```sh title="Execute the following command(s) in a terminal"
 # Set authentication for our ML experiment
 # https://dvc.org/doc/command-reference/remote/add#google-cloud-storage
 # https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -115,7 +115,7 @@ Update the `src/requirements.txt` file to include some additional packages.
 
 Here, the `dvc[gs]` package enables support for Google Cloud Storage.
 
-``` hl_lines="1"
+``` title="src/requirements.txt" hl_lines="1"
 dvc[gs]==2.37.0
 dvclive==1.0.0
 pandas==1.5.1
@@ -181,7 +181,7 @@ dvc add data/data.xml
 
 When executing this command, the following output occurs.
 
-```sh title="Execute the following command(s) in a terminal"
+```sh
 ERROR: bad DVC file name 'data/data.xml.dvc' is git-ignored.
 ```
 

--- a/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
+++ b/docs/the-guide/chapter-3-share-your-ml-experiment-data-with-dvc/index.md
@@ -288,6 +288,7 @@ Changes to be committed:
         new file:   .dvcignore
         modified:   .gitignore
         new file:   data/.gitignore
+        new file:   data/README.md
         new file:   data/data.xml.dvc
         modified:   src/requirements.txt
 ```

--- a/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/.gitignore
+++ b/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
+++ b/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
@@ -56,7 +56,10 @@ them for you. At the end of this chapter, DVC should have updated all the
 Update the `.gitignore` file to remove your experiment data. The required files
 to be ignored will then be added by DVC.
 
-```sh title="Execute the following command(s) in a terminal" hl_lines="9-11"
+```sh title=".gitignore" hl_lines="12-14"
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments
@@ -251,7 +254,10 @@ see all the stages and their dependencies.
 Notice that DVC also updated the main `.gitignore` file with the model, as it is an output of the
 `train` stage.
 
-```sh title="Execute the following command(s) in a terminal" hl_lines="12"
+```sh title=".gitignore" hl_lines="15"
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
+++ b/docs/the-guide/chapter-4-reproduce-the-experiment-with-dvc/index.md
@@ -87,7 +87,10 @@ diff --git a/.gitignore b/.gitignore
 index 6755ab0..be446de 100644
 --- a/.gitignore
 +++ b/.gitignore
-@@ -1,10 +1,3 @@
+@@ -1,13 +1,6 @@
+ ## Macos Specific
+ .DS_Store
+
 -# Data used to train the models
 -data/features
 -data/prepared
@@ -96,10 +99,10 @@ index 6755ab0..be446de 100644
 -*.pkl
 -
  ## Python
- 
+
  # Environments
-@@ -12,3 +5,7 @@ data/prepared
- 
+@@ -15,3 +8,8 @@ data/prepared
+
  # Byte-compiled / optimized / DLL files
  __pycache__/
 +

--- a/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/.gitignore
+++ b/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/index.md
+++ b/docs/the-guide/chapter-5-track-model-evolutions-with-dvc/index.md
@@ -164,7 +164,10 @@ This directory should be ignored by Git.
 
 Add the `dvc_plots` directory to the `.gitignore` file.
 
-```sh title="Execute the following command(s) in a terminal" hl_lines="11-12"
+```sh title=".gitignore" hl_lines="14-15"
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/.gitignore
+++ b/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/index.md
+++ b/docs/the-guide/chapter-6-orchestrate-the-workflow-with-a-cicd-pipeline/index.md
@@ -33,7 +33,7 @@ Create the Google Service Account and its associated Google Service Account Key 
 
 Replace  `<id of your gcp project>` with your own project ID.
 
-The key will be stored in your **Downloads** directory under the name `google-service-account-key.json`.
+The key will be stored in your **~/.config/gcloud** directory under the name `dvc-google-service-account-key.json`.
 
 !!! danger
 
@@ -51,7 +51,7 @@ gcloud projects add-iam-policy-binding <id of your gcp project> \
 	--role="roles/viewer"
 
 # Create the Google Service Account Key
-gcloud iam service-accounts keys create ~/Downloads/google-service-account-key.json \
+gcloud iam service-accounts keys create ~/.config/gcloud/dvc-google-service-account-key.json \
 	--iam-account=dvc-service-account@<id of your gcp project>.iam.gserviceaccount.com
 ```
 
@@ -71,7 +71,7 @@ Please refer to the correct instructions based on your Git repository provider.
 
 	```sh title="Execute the following command(s) in a terminal"
 	# Display the Google Service Account key
-	cat ~/Downloads/google-service-account-key.json
+	cat ~/.config/gcloud/dvc-google-service-account-key.json
 	```
 
 === ":simple-gitlab: GitLab"
@@ -82,11 +82,11 @@ Please refer to the correct instructions based on your Git repository provider.
 
 	!!! tip
 
-		If on Linux, you can use the command `base64 -w 0 -i ~/Downloads/google-service-account-key.json`.
+		If on Linux, you can use the command `base64 -w 0 -i ~/.config/gcloud/dvc-google-service-account-key.json`.
 
 	```sh title="Execute the following command(s) in a terminal"
 	# Encode the Google Service Account key to base64
-	base64 -i ~/Downloads/google-service-account-key.json
+	base64 -i ~/.config/gcloud/dvc-google-service-account-key.json
 	```
 
 ### Store the Google Service Account key as a CI/CD variable

--- a/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/.gitignore
+++ b/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/index.md
+++ b/docs/the-guide/chapter-7-track-model-evolutions-in-the-cicd-pipeline-with-cml/index.md
@@ -700,6 +700,10 @@ git push
 	should automatically appear. Click on it. Name the pull request and select
 	**Create pull request**.
 
+	!!! info
+
+		You might need to wait for the pipeline to finish before the button appears.
+
 === ":simple-gitlab: GitLab"
 
 	The merge request has already been created from the issue earlier, you can

--- a/docs/the-guide/chapter-8-serve-the-model-with-mlem/.gitignore
+++ b/docs/the-guide/chapter-8-serve-the-model-with-mlem/.gitignore
@@ -1,3 +1,6 @@
+## Macos Specific
+.DS_Store
+
 ## Python
 
 # Environments

--- a/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
+++ b/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
@@ -413,21 +413,28 @@ index e18629a..53a17a7 100644
 @@ -10,6 +10,7 @@ from sklearn import tree
  from dvclive import Live
  from matplotlib import pyplot as plt
- 
+
 +from mlem.api import load
- 
+
  if len(sys.argv) != 3:
      sys.stderr.write("Arguments error. Usage:\n")
-@@ -19,8 +20,7 @@ if len(sys.argv) != 3:
+@@ -19,14 +20,13 @@ if len(sys.argv) != 3:
  model_file = sys.argv[1]
  matrix_file = os.path.join(sys.argv[2], "test.pkl")
- 
+
 -with open(model_file, "rb") as fd:
 -    model = pickle.load(fd)
 +model = load(model_file)
- 
+
  with open(matrix_file, "rb") as fd:
      matrix, feature_names = pickle.load(fd)
+
+ labels = matrix[:, 1].toarray().astype(int)
+-x = matrix[:, 2:]
++x = matrix[:, 2:].toarray()
+
+ predictions_by_class = model.predict_proba(x)
+ predictions = predictions_by_class[:, 1]
 ```
 
 !!! info

--- a/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
+++ b/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
@@ -563,7 +563,7 @@ mlem serve fastapi --model models/rf
 ```
 
 MLEM will load the model, create the FastAPI app and start it. You can then
-access the auto-generated model documentation on <http://0.0.0.0:8080/docs>.
+access the auto-generated model documentation on <http://localhost:8080/docs>.
 
 !!! info
 

--- a/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
+++ b/docs/the-guide/chapter-8-serve-the-model-with-mlem/index.md
@@ -21,7 +21,7 @@ In this chapter, you will learn how to:
 
 Update the `src/requirements.txt` file to include mlem and its dependencies.
 
-``` hl_lines="8"
+``` title="src/requirements.txt" hl_lines="8"
 dvc[gs]==2.37.0
 dvclive==1.0.0
 pandas==1.5.1
@@ -83,7 +83,7 @@ working directory. This file contains the configuration of MLEM.
 Update the `src/featurization.py` file to save the `CountVectorizer` and the
 `TfidfTransformer` with MLEM.
 
-```py hl_lines="11 74-75"
+```py title="src/featurization.py" hl_lines="11 74-75"
 import os
 import pickle
 import sys
@@ -211,7 +211,7 @@ ames, train_output)
 
 Update the `src/train.py` file to save the model with its artifacts with MLEM.
 
-```py hl_lines="9 40-48"
+```py title="src/train.py" hl_lines="9 40-48"
 import os
 import pickle
 import sys
@@ -314,7 +314,7 @@ index 97bb9d0..87e4756 100644
 
 Update the `src/evaluate.py` file to load the model from MLEM.
 
-```py hl_lines="13 23"
+```py title="src/evaluate.py" hl_lines="13 23"
 import json
 import math
 import os


### PR DESCRIPTION
Below are the changes mentioned in the issue #16. I have add more details for some specific commits.

### Clarify gcloud login command (67be225c480387e6f3e8411fb6eb6cb1c385f881)
 The issue I encountered was running `gcloud init`. At this step, gcloud asked me to login and enter my project. This can confuse the user thinking that they do not have to run the following commands:
```sh
...
# List all available projects
gcloud projects list

# Select your Google Cloud project
gcloud config set project <id of your gcp project>

# Set authentication for our ML experiment
# https://dvc.org/doc/command-reference/remote/add#google-cloud-storage
# https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
gcloud auth application-default login
```

However if `gcloud auth application-default login` is not executed by the user, they will get an authentication error later when creating the GCP bucket.

The solution was to separate the code block into two, letting the user know that one is for initialising gcloud and the other one is for authentication.


### Update download path of GCP service account (a0a45132d407d47c58377d02d92b3441ec7a930d)
The original download path was set to `~/Downloads` which seems to be a bit unsafe.

The solution was to move it to `~/.config/gcloud` with the reset of the credentials. In order to avoid overwriting a potential service account key already in this location, the filename was renamed from `google-service-account.json` to `dvc-google-service-account.json`


### Update FastAPI local url (6facf0a233ea00274ddc461fc46c9e110e95e0f2)
The original url `http://0.0.0.0:8080/docs` was broken on macOS.
