### PR TITLE
Adjust link to new dvc gs documentation

### DIFF
--- a/docs/part-2-move-the-model-to-the-cloud/chapter-6-move-the-ml-experiment-data-to-the-cloud.md
+++ b/docs/part-2-move-the-model-to-the-cloud/chapter-6-move-the-ml-experiment-data-to-the-cloud.md
@@ -172,7 +172,7 @@ Install and configure the cloud provider CLI tool to manage the cloud resources.
 
     ```sh title="Execute the following command(s) in a terminal"
     # Set authentication for our ML experiment
-    # https://dvc.org/doc/command-reference/remote/add#google-cloud-storage
+    # https://dvc.org/doc/user-guide/data-management/remote-storage/google-cloud-storage
     # https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
     gcloud auth application-default login
     ```


### PR DESCRIPTION
The existing link is obsolete, as the DVC doc website moved pages around since then.