### PR TITLE
Add venv activation warning

### DIFF
--- a/docs/part-1-local-training-and-model-evaluation/chapter-3-initialize-git-and-dvc-for-local-training.md
+++ b/docs/part-1-local-training-and-model-evaluation/chapter-3-initialize-git-and-dvc-for-local-training.md
@@ -227,6 +227,16 @@ index 250f32c..193ebac 100644
 
 Install the dependencies and update the freeze file.
 
+!!! warning
+
+    Prior to running any `pip` commands, it is crucial to ensure the virtual
+    environment is activated to avoid potential conflicts with system-wide Python
+    packages.
+
+    To check its status, simply run `pip -V`. If the virtual environment is active,
+    the output will show the path to the virtual environment's Python executable. If
+    it is not, you can activate it with `source .venv/bin/activate`.
+
 ```sh title="Execute the following command(s) in a terminal"
 # Install the requirements
 pip install --requirement requirements.txt

--- a/docs/part-2-move-the-model-to-the-cloud/chapter-6-move-the-ml-experiment-data-to-the-cloud.md
+++ b/docs/part-2-move-the-model-to-the-cloud/chapter-6-move-the-ml-experiment-data-to-the-cloud.md
@@ -310,6 +310,16 @@ Install the DVC Storage plugin for the chosen cloud provider.
 
     Install the dependencies and update the freeze file.
 
+    !!! warning
+
+        Prior to running any `pip` commands, it is crucial to ensure the virtual
+        environment is activated to avoid potential conflicts with system-wide Python
+        packages.
+
+        To check its status, simply run `pip -V`. If the virtual environment is active,
+        the output will show the path to the virtual environment's Python executable. If
+        it is not, you can activate it with `source .venv/bin/activate`.
+
     ```sh title="Execute the following command(s) in a terminal"
     # Install the requirements
     pip install --requirement requirements.txt


### PR DESCRIPTION
Prior to running any pip commands, it is crucial to activate the virtual
environment to avoid potential conflicts with system-wide Python packages.

Add a warning on relevant section, as it is way too easy to forget about it (especially when using multiple terminal prompts)