### PR TITLE
Split State of the MLOps process checklist by parts

### DIFF
--- a/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
@@ -278,8 +278,7 @@ In the next chapters, you will enhance the workflow to fix those issues.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
@@ -277,20 +277,6 @@ In the next chapters, you will enhance the workflow to fix those issues.
 - [ ] Codebase and dataset are not versioned
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
-- [ ] Codebase requires manual download and setup
-- [ ] Dataset requires manual download and placement
-- [ ] Experiment may not be reproducible on other machines
-- [ ] CI/CD pipeline does not report the results of the experiment
-- [ ] Changes to model are not thoroughly reviewed and discussed before
-      integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md
@@ -278,8 +278,8 @@ In the next chapters, you will enhance the workflow to fix those issues.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
@@ -869,8 +869,8 @@ You can now safely continue to the next chapter.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
@@ -869,8 +869,7 @@ You can now safely continue to the next chapter.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-12-adapt-and-move-the-jupyter-notebook-to-python-scripts.md
@@ -868,20 +868,6 @@ You can now safely continue to the next chapter.
 - [ ] Codebase and dataset are not versioned
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
-- [ ] Codebase requires manual download and setup
-- [ ] Dataset requires manual download and placement
-- [ ] Experiment may not be reproducible on other machines
-- [ ] CI/CD pipeline does not report the results of the experiment
-- [ ] Changes to model are not thoroughly reviewed and discussed before
-      integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
@@ -499,8 +499,8 @@ You can now safely continue to the next chapter.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
@@ -499,8 +499,7 @@ You can now safely continue to the next chapter.
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
@@ -498,20 +498,6 @@ You can now safely continue to the next chapter.
 - [x] Codebase and dataset are versioned
 - [ ] Model steps rely on verbal communication and may be undocumented
 - [ ] Changes to model are not easily visualized
-- [ ] Codebase requires manual download and setup
-- [ ] Dataset requires manual download and placement
-- [ ] Experiment may not be reproducible on other machines
-- [ ] CI/CD pipeline does not report the results of the experiment
-- [ ] Changes to model are not thoroughly reviewed and discussed before
-      integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
@@ -423,20 +423,6 @@ You can now safely continue to the next chapter.
 - [x] Codebase and dataset are versioned
 - [x] Steps used to create the model are documented and can be re-executed
 - [ ] Changes to model are not easily visualized
-- [ ] Codebase requires manual download and setup
-- [ ] Dataset requires manual download and placement
-- [ ] Experiment may not be reproducible on other machines
-- [ ] CI/CD pipeline does not report the results of the experiment
-- [ ] Changes to model are not thoroughly reviewed and discussed before
-      integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
@@ -424,8 +424,7 @@ You can now safely continue to the next chapter.
 - [x] Steps used to create the model are documented and can be re-executed
 - [ ] Changes to model are not easily visualized
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-14-reproduce-the-ml-experiment-with-dvc.md
@@ -424,8 +424,8 @@ You can now safely continue to the next chapter.
 - [x] Steps used to create the model are documented and can be re-executed
 - [ ] Changes to model are not easily visualized
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
@@ -315,8 +315,8 @@ You can now safely continue to the next chapter.
 - [x] Changes done to a model can be visualized with parameters, metrics and
       plots to identify differences between iterations
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You have completed the objectives of this part. Continue to Part 2 to learn how
+to move your experiment to the cloud.
 
 ## Sources
 

--- a/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
@@ -314,20 +314,6 @@ You can now safely continue to the next chapter.
 - [x] Steps used to create the model are documented and can be re-executed
 - [x] Changes done to a model can be visualized with parameters, metrics and
       plots to identify differences between iterations
-- [ ] Codebase requires manual download and setup
-- [ ] Dataset requires manual download and placement
-- [ ] Experiment may not be reproducible on other machines
-- [ ] CI/CD pipeline does not report the results of the experiment
-- [ ] Changes to model are not thoroughly reviewed and discussed before
-      integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-15-track-model-evolution-with-dvc.md
@@ -315,8 +315,7 @@ You can now safely continue to the next chapter.
 - [x] Changes done to a model can be visualized with parameters, metrics and
       plots to identify differences between iterations
 
-You have completed the objectives of this part. Continue to Part 2 to learn how
-to move your experiment to the cloud.
+Continue to the conclusion to review what you have learned.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
@@ -158,25 +158,12 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
 - [x] Codebase can be shared and improved by multiple developers
 - [ ] Dataset requires manual download and placement
 - [ ] Experiment may not be reproducible on other machines
 - [ ] CI/CD pipeline does not report the results of the experiment
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
@@ -165,8 +165,7 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-21-move-the-ml-experiment-code-to-the-cloud.md
@@ -165,8 +165,8 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
@@ -442,8 +442,8 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
@@ -434,11 +434,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
 - [x] Codebase can be shared and improved by multiple developers
 - [x] Dataset can be shared among the developers and is placed in the right
       directory in order to run the experiment
@@ -446,14 +441,6 @@ You can now safely continue to the next chapter.
 - [ ] CI/CD pipeline does not report the results of the experiment
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
+++ b/docs/part-2-move-to-the-cloud/chapter-22-move-the-ml-experiment-data-to-the-cloud.md
@@ -442,8 +442,7 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
+++ b/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
@@ -297,11 +297,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
 - [x] Codebase can be shared and improved by multiple developers
 - [x] Dataset can be shared among the developers and is placed in the right
       directory in order to run the experiment
@@ -310,14 +305,6 @@ You can now safely continue to the next chapter.
 - [ ] CI/CD pipeline does not report the results of the experiment
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
+++ b/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
@@ -306,8 +306,7 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
+++ b/docs/part-2-move-to-the-cloud/chapter-23-reproduce-the-ml-experiment-in-a-cicd-pipeline.md
@@ -306,8 +306,8 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
+++ b/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
@@ -362,11 +362,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
 - [x] Codebase can be shared and improved by multiple developers
 - [x] Dataset can be shared among the developers and is placed in the right
       directory in order to run the experiment
@@ -376,14 +371,6 @@ You can now safely continue to the next chapter.
       the experiment
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
+++ b/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
@@ -372,8 +372,8 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
+++ b/docs/part-2-move-to-the-cloud/chapter-24-track-model-evolution-in-the-cicd-pipeline-with-cml.md
@@ -372,8 +372,7 @@ You can now safely continue to the next chapter.
 - [ ] Changes to model are not thoroughly reviewed and discussed before
       integration
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
+++ b/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
@@ -363,8 +363,7 @@ You can now safely continue to the next chapter.
 - [x] Changes to model can be thoroughly reviewed and discussed before
       integrating them into the codebase
 
-You have completed the objectives of this part. Continue to Part 3 to learn how
-to serve and deploy your model.
+Continue to the conclusion to review what you have learned.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
+++ b/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
@@ -363,8 +363,8 @@ You can now safely continue to the next chapter.
 - [x] Changes to model can be thoroughly reviewed and discussed before
       integrating them into the codebase
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You have completed the objectives of this part. Continue to Part 3 to learn how
+to serve and deploy your model.
 
 ## Sources
 

--- a/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
+++ b/docs/part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md
@@ -353,11 +353,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
 - [x] Codebase can be shared and improved by multiple developers
 - [x] Dataset can be shared among the developers and is placed in the right
       directory in order to run the experiment
@@ -367,14 +362,6 @@ You can now safely continue to the next chapter.
       the experiment
 - [x] Changes to model can be thoroughly reviewed and discussed before
       integrating them into the codebase
-- [ ] Model may have required artifacts that are forgotten or omitted in
-      saved/loaded state
-- [ ] Model cannot be easily used from outside of the experiment context
-- [ ] Model requires manual publication to the artifact registry
-- [ ] Model is not accessible on the Internet and cannot be used anywhere
-- [ ] Model requires manual deployment on the cluster
-- [ ] Model cannot be trained on hardware other than the local machine
-- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You will address these issues in the next chapters for improved efficiency and
 collaboration. Continue the guide to learn how.

--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -724,20 +724,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [ ] Model cannot be easily used from outside of the experiment context
 - [ ] Model requires manual publication to the artifact registry

--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -732,8 +732,8 @@ You can now safely continue to the next chapter.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -732,8 +732,7 @@ You can now safely continue to the next chapter.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
@@ -346,8 +346,8 @@ You can now safely continue to the next chapter.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
@@ -346,8 +346,7 @@ You can now safely continue to the next chapter.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-32-serve-the-model-locally-with-bentoml.md
@@ -338,20 +338,6 @@ You can now safely continue to the next chapter.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [ ] Model requires manual publication to the artifact registry

--- a/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
+++ b/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
@@ -522,24 +522,10 @@ In this chapter, you have successfully:
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [ ] Model requires manual publication to the artifact registry
-- [ ] Model is accessible from the Internet and can be used anywhere
+- [ ] Model is not accessible on the Internet and cannot be used anywhere
 - [ ] Model requires manual deployment on the cluster
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases

--- a/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
+++ b/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
@@ -530,8 +530,8 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
+++ b/docs/part-3-serve-and-deploy/chapter-33-build-and-publish-the-model-with-bentoml-and-docker-locally.md
@@ -530,8 +530,7 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
@@ -392,8 +392,8 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
@@ -384,24 +384,10 @@ In this chapter, you have successfully:
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [x] Model publication to the artifact registry is automated
-- [ ] Model is accessible from the Internet and can be used anywhere
+- [ ] Model is not accessible on the Internet and cannot be used anywhere
 - [ ] Model requires manual deployment on the cluster
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases

--- a/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-34-build-and-publish-the-model-with-bentoml-and-docker-with-the-cicd-pipeline.md
@@ -392,8 +392,7 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -471,20 +471,6 @@ In this chapter, you have successfully:
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [x] Model publication to the artifact registry is automated

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -479,8 +479,7 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -479,8 +479,8 @@ In this chapter, you have successfully:
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address these issues in the next chapters for improved efficiency and
-collaboration. Continue the guide to learn how.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
@@ -439,24 +439,10 @@ pushed to the main branch.
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [x] Model publication to the artifact registry is automated
-- [x] Model can be accessed from a Kubernetes cluster
+- [x] Model is accessible from the Internet and can be used anywhere
 - [x] Model is continuously deployed with the CI/CD
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases

--- a/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
@@ -447,8 +447,7 @@ pushed to the main branch.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-36-continuous-deployment-of-the-model-with-the-cicd-pipeline.md
@@ -447,8 +447,8 @@ pushed to the main branch.
 - [ ] Model cannot be trained on hardware other than the local machine
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You can now safely continue to the next chapter of this guide concluding your
-journey and the next things you could do with your model.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -949,8 +949,8 @@ In this chapter, you have successfully:
 - [x] Model can be trained on a custom infrastructure
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You can now safely continue to the next chapter of this guide concluding your
-journey and the next things you could do with your model.
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -949,8 +949,7 @@ In this chapter, you have successfully:
 - [x] Model can be trained on a custom infrastructure
 - [ ] Model cannot be trained on custom hardware for specific use-cases
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -941,28 +941,13 @@ In this chapter, you have successfully:
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [x] Model publication to the artifact registry is automated
-- [x] Model can be accessed from a Kubernetes cluster
+- [x] Model is accessible from the Internet and can be used anywhere
 - [x] Model is continuously deployed with the CI/CD
 - [x] Model can be trained on a custom infrastructure
-- [ ] Model can be trained on a custom infrastructure with custom hardware for
-      specific use-cases
+- [ ] Model cannot be trained on custom hardware for specific use-cases
 
 You can now safely continue to the next chapter of this guide concluding your
 journey and the next things you could do with your model.

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -911,24 +911,10 @@ gcloud container clusters delete --zone $GCP_K8S_CLUSTER_ZONE $GCP_K8S_CLUSTER_N
 
 ## State of the MLOps process
 
-- [x] Notebook has been transformed into scripts for production
-- [x] Codebase and dataset are versioned
-- [x] Steps used to create the model are documented and can be re-executed
-- [x] Changes done to a model can be visualized with parameters, metrics and
-      plots to identify differences between iterations
-- [x] Codebase can be shared and improved by multiple developers
-- [x] Dataset can be shared among the developers and is placed in the right
-      directory in order to run the experiment
-- [x] Experiment can be executed on a clean machine with the help of a CI/CD
-      pipeline
-- [x] CI/CD pipeline is triggered on pull requests and reports the results of
-      the experiment
-- [x] Changes to model can be thoroughly reviewed and discussed before
-      integrating them into the codebase
 - [x] Model can be saved and loaded with all required artifacts for future usage
 - [x] Model can be easily used outside of the experiment context
 - [x] Model publication to the artifact registry is automated
-- [x] Model can be accessed from a Kubernetes cluster
+- [x] Model is accessible from the Internet and can be used anywhere
 - [x] Model is continuously deployed with the CI/CD
 - [x] Model can be trained on a custom infrastructure
 - [x] Model can be trained on a custom infrastructure with custom hardware for

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -920,9 +920,7 @@ gcloud container clusters delete --zone $GCP_K8S_CLUSTER_ZONE $GCP_K8S_CLUSTER_N
 - [x] Model can be trained on a custom infrastructure with custom hardware for
       specific use-cases
 
-You have completed the objectives of this part. Continue to Part 4 to learn how
-to monitor and maintain your model, and to Part 5 to learn how to label data and
-retrain it.
+Continue to the conclusion to review what you have learned.
 
 ## Sources
 

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -920,8 +920,9 @@ gcloud container clusters delete --zone $GCP_K8S_CLUSTER_ZONE $GCP_K8S_CLUSTER_N
 - [x] Model can be trained on a custom infrastructure with custom hardware for
       specific use-cases
 
-You can now safely continue to the next chapter of this guide concluding your
-journey and the next things you could do with your model.
+You have completed the objectives of this part. Continue to Part 4 to learn how
+to monitor and maintain your model, and to Part 5 to learn how to label data and
+retrain it.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
@@ -314,11 +314,14 @@ and imported new data. You are now ready to start labeling your data!
       you to prototype labeling workflows quickly and iterate on the annotation schema
       before scaling to production.
 
-## State of the labeling process
+## State of the MLOps process
 
-- [ ] Labeling of supplemental data needs to be systematic and uniform
+- [ ] Labeling of supplemental data is not systematic or uniform
 - [ ] Labeling of supplemental data is time intensive
 - [ ] Model needs to be retrained using higher-quality data
+
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
@@ -320,8 +320,7 @@ and imported new data. You are now ready to start labeling your data!
 - [ ] Labeling of supplemental data is time intensive
 - [ ] Model needs to be retrained using higher-quality data
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
@@ -108,12 +108,15 @@ That concludes this chapter.
       across the dataset, reducing the noise that can harm model performance when
       different annotators use different standards.
 
-## State of the labeling process
+## State of the MLOps process
 
 - [x] Labeling of supplemental data can be done systematically and uniformly
 - [ ] Labeling of supplemental data is time intensive
 - [ ] Model needs to be retrained using higher-quality data
 
-## Souces
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
+
+## Sources
 
 - [_Label Studio Labeling Guide_](https://labelstud.io/guide/labeling)

--- a/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
@@ -114,8 +114,7 @@ That concludes this chapter.
 - [ ] Labeling of supplemental data is time intensive
 - [ ] Model needs to be retrained using higher-quality data
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
@@ -379,11 +379,14 @@ data we have labeled.
       pressure or with large datasets. Implementing cross-labeling and quality checks
       helps mitigate this risk.
 
-## State of the labeling process
+## State of the MLOps process
 
 - [x] Labeling of supplemental data can be done systematically and uniformly
 - [x] Labeling of supplemental data is accelerated with AI assistance
 - [ ] Model needs to be retrained using higher-quality data
+
+You will address the remaining items in the next chapters of this part for
+improved efficiency and collaboration. Continue the guide to learn how.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
@@ -385,8 +385,7 @@ data we have labeled.
 - [x] Labeling of supplemental data is accelerated with AI assistance
 - [ ] Model needs to be retrained using higher-quality data
 
-You will address the remaining items in the next chapters of this part for
-improved efficiency and collaboration. Continue the guide to learn how.
+Continue to the next chapters to address the remaining items.
 
 ## Sources
 

--- a/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
+++ b/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
@@ -237,5 +237,4 @@ using DVC. We then evaluated the new model to see if it has improved.
 - [x] Labeling of supplemental data is accelerated with AI assistance
 - [x] Model is retrained with the supplemental data
 
-You have completed the objectives of this part. Continue to the conclusion to
-review what you have learned and explore the next steps.
+Continue to the conclusion to review what you have learned.

--- a/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
+++ b/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
@@ -231,8 +231,11 @@ using DVC. We then evaluated the new model to see if it has improved.
       retraining, making it immediately clear whether the newly labeled data improved
       model performance or introduced new issues that need investigation.
 
-## State of the labeling process
+## State of the MLOps process
 
 - [x] Labeling of supplemental data can be done systematically and uniformly
 - [x] Labeling of supplemental data is accelerated with AI assistance
 - [x] Model is retrained with the supplemental data
+
+You have completed the objectives of this part. Continue to the conclusion to
+review what you have learned and explore the next steps.


### PR DESCRIPTION
Replace the global, duplicated checklist with part-specific progress lists in
each chapter. This makes the section easier to maintain and more relevant as a
"you are here" indicator.

- Part 1 tracks local training and evaluation (4 items)
- Part 2 tracks moving to the cloud (5 items)
- Part 3 tracks serving and deploying (7 items)

Also normalizes inconsistent positive/unchecked phrasing in Part 3.
