### PR TITLE
Polish home page landing content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ home:
     title: A Guide to MLOps
     subtitle: |
       Classify celestial bodies using best practices:
-      a hands-on journey through local training, the cloud, serving, monitoring, labeling, and retraining.
+      a practical journey through local training, the cloud, serving, monitoring, labeling, and retraining.
     cta:
       text: Chart the course
       icon: lucide/compass

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,9 +58,9 @@ home:
           icon: lucide/chevron-down
           anchor: "#section-part-1"
         - type: secondary
-          text: Read the concept
+          text: Read the philosophy
           icon: lucide/book-open
-          path: concept/
+          path: philosophy/
     - id: part-1
       label: Part 1 — Lift-off
       title: Local training &

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ home:
           anchor: "#section-part-1"
         - type: secondary
           text: Our philosophy
-          icon: lucide/book-open
+          icon: lucide/telescope
           path: philosophy/
     - id: part-1
       label: Part 1 — Lift-off

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,8 @@ home:
           icon: lucide/chevron-down
           anchor: "#section-part-1"
         - type: secondary
-          text: Our philosophy
-          icon: lucide/telescope
+          text: Philosophy
+          icon: lucide/lightbulb
           path: philosophy/
     - id: part-1
       label: Part 1 — Lift-off

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,7 +162,7 @@ home:
           icon: lucide/tags
           path: part-5-label-data-and-retrain/introduction/
     - id: reentry
-      label: Reentry & cleanup
+      label: Reentry
       title: Clean up &
       title_highlight: conclude
       planet: capsule

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ home:
           icon: lucide/chevron-down
           anchor: "#section-part-1"
         - type: secondary
-          text: Read the philosophy
+          text: Our philosophy
           icon: lucide/book-open
           path: philosophy/
     - id: part-1

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,7 @@ hide:
 home:
   hero:
     badge:
-      text: Mission briefing
-      icon: lucide/rocket
+      text: Hands-on tutorial
     title: A Guide to MLOps
     subtitle: |
       Classify celestial bodies using best practices:

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -212,7 +212,6 @@
   .hero-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
     padding: 0.35rem 0.75rem;
     border-radius: 0;
     background: transparent;
@@ -702,7 +701,6 @@
 <!-- Hero -->
 <section class="story-hero" id="story-hero">
   <div class="hero-badge">
-    <span class="twemoji">{% include ".icons/" ~ home.hero.badge.icon ~ ".svg" %}</span>
     {{ home.hero.badge.text }}
   </div>
   <h1 class="hero-title">{{ home.hero.title }}</h1>


### PR DESCRIPTION
- **Link home 'Why this guide?' button to Philosophy page instead of Concept**
- **Shorten home 'Why this guide?' button label to 'Our philosophy'**
- **Simplify reentry section label to 'Reentry' for space-theme consistency**
- **Use telescope icon for 'Our philosophy' home button**
- **Use lightbulb icon and shorten philosophy home button to 'Philosophy'**
- **Make hero badge text-only 'Hands'on tutorial' and remove icon from template**
- **Avoid repetition: use 'practical journey' in hero subtitle**
