### PR TITLE
Polish tools page and add AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,177 @@
+# A guide to MLOps — Agent notes
+
+Quick reference for AI coding agents working on the repository.
+
+## Project overview
+
+This repository is the source for the **"A guide to MLOps"** website at
+<https://mlops.swiss-ai-center.ch> and its companion slide deck.
+
+- It is a hands-on tutorial that takes a planet/moon image classifier from a
+  Jupyter Notebook experiment to a reproducible, deployed, monitored, and
+  retrainable ML system.
+- The tutorial covers: Git, DVC, GitHub Actions, CML, BentoML, Docker,
+  Kubernetes, Evidently AI, and Label Studio.
+- The `main` branch contains the documentation and presentation source. Related
+  artifacts live on dedicated branches:
+  - `dataset` — dataset generator
+  - `data` — dataset used for training/evaluation
+  - `extra-data` — supplementary data for inference and labeling
+  - `freeze` — backup of validated dependency pins
+
+Key files:
+
+- `README.md` — high-level description, branch layout, and local setup.
+- `zensical.toml` — documentation site generator configuration.
+- `pyproject.toml` — Python project metadata.
+- `Dockerfile` / `docker-compose.yml` — containerized local development.
+- `.github/workflows/deploy-to-github-pages.yml` — CI/CD and Pages deployment.
+
+## Technology stack
+
+- **Python 3.13** (minimum version, per `pyproject.toml`).
+- **Zensical** — documentation site generator (Material for MkDocs-based).
+- **mdwrap** — Markdown formatter/linter.
+- **Marp CLI** — builds the presentation deck.
+- **Docker / Docker Compose** — optional local dev environment.
+- **GitHub Actions** — linting, building, and deploying to GitHub Pages.
+
+Production dependencies are pinned in `requirements-freeze.txt`; direct
+dependencies are listed in `requirements.txt`.
+
+## Repository structure
+
+```text
+.
+├── docs/                         # Guide Markdown source
+│   ├── index.md                  # Story landing page
+│   ├── syllabus.md               # Tutorial overview
+│   ├── tools.md                  # Tooling overview
+│   ├── cheatsheet.md             # Terminal/command reference
+│   ├── philosophy.md
+│   ├── concept.md
+│   ├── references.md
+│   ├── glossary.md
+│   ├── clean-up.md
+│   ├── conclusion.md
+│   ├── part-1-local-training-and-evaluation/
+│   ├── part-2-move-to-the-cloud/
+│   ├── part-3-serve-and-deploy/
+│   ├── part-4-monitor-and-maintain/
+│   ├── part-5-label-data-and-retrain/
+│   ├── assets/                   # Images, CSS, JavaScript
+│   └── overrides/                # Jinja2 template overrides
+├── presentation/                 # Marp slide deck
+│   ├── README.md                 # Slide source
+│   ├── images/                   # Slide assets
+│   └── index.html                # Generated HTML deck
+├── logs/                         # Empty by default; used by monitoring chapter
+├── site/                         # Generated Zensical output (gitignored)
+├── public/                       # Final GitHub Pages artifact (gitignored)
+├── zensical.toml                 # Site generator configuration
+├── pyproject.toml                # Python project metadata
+├── requirements.txt              # Direct dependencies
+├── requirements-freeze.txt       # Pinned dependencies used by CI/Docker
+├── Dockerfile
+├── docker-compose.yml
+└── .github/workflows/deploy-to-github-pages.yml
+```
+
+## Build and serve
+
+### Python
+
+```sh
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install --requirement requirements-freeze.txt
+zensical serve
+```
+
+Open <http://localhost:8000>. The server reloads on documentation changes.
+
+### uv
+
+```sh
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install --requirement requirements-freeze.txt
+zensical serve
+```
+
+### Docker Compose
+
+```sh
+docker compose build
+docker compose up serve
+```
+
+### Production build
+
+```sh
+zensical build --clean
+```
+
+This writes the static site to `site/`.
+
+## Formatting and linting
+
+The project uses `mdwrap` to keep Markdown consistent. CI validates formatting
+and builds both the site and the presentation.
+
+- Format:
+
+  ```sh
+  mdwrap --fmt docs presentation
+  ```
+
+- Check:
+
+  ```sh
+  mdwrap --check docs presentation
+  ```
+
+## CI/CD and deployment
+
+`.github/workflows/deploy-to-github-pages.yml` runs on pushes to `main`, pull
+requests, and `workflow_dispatch`. It lints with `mdwrap --check`, builds the
+site with `zensical build --clean`, builds the presentation with Marp, merges
+both artifacts into `public/`, and deploys `public/` to GitHub Pages from
+`main`.
+
+The live site is configured in `zensical.toml`:
+
+- `site_url = "https://mlops.swiss-ai-center.ch/"`
+- `repo_url = "https://github.com/swiss-ai-center/a-guide-to-mlops"`
+
+## Development conventions
+
+- Markdown files use **4-space indentation** (`.editorconfig`).
+- Keep Markdown sources under `docs/` and `presentation/README.md` wrapped and
+  formatted with `mdwrap`.
+- The guide relies on Zensical/Material for MkDocs features configured in
+  `zensical.toml`: admonitions, footnotes, content tabs, task lists, code
+  annotations, Mermaid diagrams, emoji, and MathJax.
+- Shell instructions use fenced code blocks with a title.
+- Alternate tooling choices use content tabs.
+- Navigation is explicit in `zensical.toml` (`nav` array), not derived from the
+  directory structure.
+- Custom templates live in `docs/overrides/`. `docs/index.md` renders with
+  `docs/overrides/home.html`.
+
+## Security and cost considerations
+
+The guide instructs readers to create cloud resources (Google Cloud projects,
+GitHub tokens, container registries, Kubernetes clusters, S3 buckets, etc.).
+`docs/clean-up.md` explains how to remove them.
+
+No credentials or secrets are stored in this repository.
+
+## Useful references
+
+- `README.md` — branch layout and quick setup.
+- `zensical.toml` — site name, URL, navigation, theme, palette, and Markdown
+  extensions.
+- `.github/workflows/deploy-to-github-pages.yml` — full CI/CD pipeline.
+- `docs/tools.md` — overview of the MLOps tools used in the tutorial.
+- `docs/syllabus.md` — tutorial structure and chapter list.

--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -127,9 +127,9 @@ Install the package and update the freeze file.
     environment is activated to avoid potential conflicts with system-wide Python
     packages.
 
-    To check its status, simply run `pip -V`. If the virtual environment is active,
-    the output will show the path to the virtual environment's Python executable. If
-    it is not, you can activate it with `source .venv/bin/activate`.
+    To check its status, simply run `which python`. If the virtual environment is
+    active, the output will show the path to the virtual environment's Python
+    executable. If it is not, you can activate it with `source .venv/bin/activate`.
 
 === ":simple-python: Using pip"
 

--- a/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
@@ -154,9 +154,9 @@ Install the package and update the freeze file.
     environment is activated to avoid potential conflicts with system-wide Python
     packages.
 
-    To check its status, simply run `pip -V`. If the virtual environment is active,
-    the output will show the path to the virtual environment's Python executable. If
-    it is not, you can activate it with `source .venv/bin/activate`.
+    To check its status, simply run `which python`. If the virtual environment is
+    active, the output will show the path to the virtual environment's Python
+    executable. If it is not, you can activate it with `source .venv/bin/activate`.
 
 === ":simple-python: Using pip"
 

--- a/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-53-link-the-model-to-label-studio.md
@@ -87,9 +87,9 @@ Install the package and update the freeze file.
     environment is activated to avoid potential conflicts with system-wide Python
     packages.
 
-    To check its status, simply run `pip -V`. If the virtual environment is active,
-    the output will show the path to the virtual environment's Python executable. If
-    it is not, you can activate it with `source .venv/bin/activate`.
+    To check its status, simply run `which python`. If the virtual environment is
+    active, the output will show the path to the virtual environment's Python
+    executable. If it is not, you can activate it with `source .venv/bin/activate`.
 
 === ":simple-python: Using pip"
 

--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -2,10 +2,10 @@
 
 What you will learn.
 
-This hands-on tutorial begins with a Jupyter notebook experiment and
-progressively turns it into a reproducible, deployed, and maintainable system.
-The chapters that follow walk through that lifecycle, from a local notebook to a
-deployed, monitored, and retrainable system.
+This hands-on tutorial walks through the full MLOps lifecycle: from a local
+Jupyter notebook experiment to a reproducible pipeline, then to automated
+collaboration in the cloud, and finally to a deployed, monitored, and
+retrainable system.
 
 The five parts are:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -49,14 +49,14 @@ These are alternatives to DVC.
 - [Delta Lake](https://delta.io/) - An open-source storage framework that
   enables building a Lakehouse architecture with compute engines
 
-### Monitoring/tracking
+### Experiment tracking
 
-These are alternatives to CML.
+These are alternatives to CML for tracking experiments and reporting metrics in
+CI/CD pipelines.
 
-- [GuildAi](https://guild.ai/) - An open source experiment tracking toolkit. Use
-  it to build better machine learning models faster
-- [Aim](https://aimstack.io/) - An open-source, self-hosted ML experiment
-  tracking tool
+- [GuildAi](https://guild.ai/) - Open-source experiment tracking toolkit
+- [Aim](https://aimstack.io/) - Open-source, self-hosted ML experiment tracking
+  tool
 
 ### Data annotation
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,16 +10,15 @@ process:
 - Code management: [:simple-git: Git](https://git-scm.com/)
 - Package management: [:simple-python: pip](https://pip.pypa.io/) (or
   [:simple-uv: uv](https://docs.astral.sh/uv/) as an alternative)
-- Data management: [:simple-dvc: DVC](https://dvc.org/)
-- Model reproducibility: [:simple-dvc: DVC](https://dvc.org/)
-- Model tracking: [:simple-dvc: DVC](https://dvc.org/) & [CML](https://cml.dev/)
-- Model orchestration:
+- Data and model versioning: [:simple-dvc: DVC](https://dvc.org/)
+- ML experiment reporting: [CML](https://cml.dev/)
+- Pipeline orchestration:
   [:simple-github: GitHub Actions](https://github.com/features/actions)
-- A [:simple-googlecloud: Google Cloud](https://cloud.google.com) account
-- Model serving and distributing:
-  [:simple-bentoml: BentoML](https://bentoml.com/) and
-  [:simple-docker: Docker](https://docker.com/)
-- Model deploying: [:simple-kubernetes: Kubernetes](https://kubernetes.io/)
+- Cloud infrastructure:
+  [:simple-googlecloud: Google Cloud](https://cloud.google.com)
+- Model packaging and serving: [:simple-bentoml: BentoML](https://bentoml.com/)
+  and [:simple-docker: Docker](https://docker.com/)
+- Model deployment: [:simple-kubernetes: Kubernetes](https://kubernetes.io/)
 - Model monitoring: [Evidently AI](https://evidentlyai.com/)
 - Data annotation: [Label Studio](https://labelstud.io/)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,11 +1,6 @@
 # Tools
 
-Introduction to the tools used in this guide.
-
-## What are the tools used in this guide?
-
-In this guide, you will use the following tools to demonstrate the MLOps
-process:
+This guide uses the following tools:
 
 - Code management: [:simple-git: Git](https://git-scm.com/)
 - Package management: [:simple-python: pip](https://pip.pypa.io/) (or
@@ -22,34 +17,26 @@ process:
 - Model monitoring: [Evidently AI](https://evidentlyai.com/)
 - Data annotation: [Label Studio](https://labelstud.io/)
 
-You will go into details about each tool in the following parts of this guide.
+The following chapters explain each tool in detail.
 
 ## Related tools
 
-While this guide concentrates solely on the setup and utilization of the
-mentioned tools, it is worth noting that there are alternative tools available
-for each stage of the workflow.
-
-Here is a list of related tools that can be explored as alternatives.
-Additionally, you can find another valuable compilation of tools at
-[MLOps.toys](https://tools.mlops.community/).
+This guide covers one toolset, but alternatives exist for every stage. For a
+broader compilation, see [MLOps.toys](https://tools.mlops.community/).
 
 ### Data management
 
-These are alternatives to DVC.
+Alternatives to DVC.
 
-- [LakeFS](https://lakefs.io/) - Transform your data lake into a Git-like
-  repository
-- [DagsHub](https://dagshub.com/) - Open Source Data Science Collaboration
-- [DoltHub](https://www.dolthub.com/) - DoltHub is where people collaboratively
-  build, manage, and distribute structured data
-- [Delta Lake](https://delta.io/) - An open-source storage framework that
-  enables building a Lakehouse architecture with compute engines
+- [LakeFS](https://lakefs.io/) - Git-like version control for data lakes
+- [DagsHub](https://dagshub.com/) - Data science collaboration platform
+- [DoltHub](https://www.dolthub.com/) - Collaborative versioned databases
+- [Delta Lake](https://delta.io/) - Open-source storage layer for lakehouses
 
 ### Experiment tracking
 
-These are alternatives to CML for tracking experiments and reporting metrics in
-CI/CD pipelines.
+Alternatives to CML for tracking experiments and reporting metrics in CI/CD
+pipelines.
 
 - [GuildAi](https://guild.ai/) - Open-source experiment tracking toolkit
 - [Aim](https://aimstack.io/) - Open-source, self-hosted ML experiment tracking
@@ -60,7 +47,7 @@ CI/CD pipelines.
 These are alternatives to Evidently AI for monitoring models in production.
 
 - [NannyML](https://www.nannyml.com/) - Detect model and data drift, including
-  estimated performance degradation, without needing ground truth labels
+  estimated performance degradation, without ground truth labels
 - [Deepchecks](https://deepchecks.com/) - Test and validate ML models and data,
   with a library or self-hosted UI
 - [Seldon Alibi Detect](https://github.com/SeldonIO/alibi-detect) - Algorithms
@@ -68,15 +55,14 @@ These are alternatives to Evidently AI for monitoring models in production.
 
 ### Data annotation
 
-At the moment, Label Studio is the only solution that allows to annotate many
-kinds of data. Other competitors only allow a certain kind of data. Have a look
-at the
+Label Studio handles many data types, but most competitors specialize in one.
+See the
 [`awesome-data-labeling`](https://github.com/heartexlabs/awesome-data-labeling)
-Git repository for specific alternatives.
+repository for specific alternatives.
 
 ### Pipeline orchestration
 
-These are alternatives to GitHub Actions.
+Alternatives to GitHub Actions.
 
 - [GitLab CI](https://about.gitlab.com/topics/ci-cd/) - DevOps platform with
   built-in CI/CD and container registry
@@ -87,7 +73,7 @@ These are alternatives to GitHub Actions.
 
 ### Model packaging and serving
 
-These are alternatives to BentoML for packaging and serving models.
+Alternatives to BentoML for packaging and serving models.
 
 - [MLEM](https://mlem.ai/) - Open-source tool to simplify ML model deployments
 - [Cog](https://github.com/replicate/cog) - Package machine learning models in
@@ -99,18 +85,18 @@ These are alternatives to BentoML for packaging and serving models.
 
 ### Container tools
 
-These are alternatives to Docker.
+Alternatives to Docker.
 
 - [Podman](https://podman.io/) - Daemonless, open-source tool for running,
   building, and sharing OCI containers and images
 
-### Self-hosted / on-premise infrastructure
+### Self-hosted infrastructure
 
-These tools are useful if you want to run the MLOps stack on your own
-infrastructure instead of managed cloud services.
+Tools for running the MLOps stack on your own hardware instead of managed cloud
+services.
 
-- [CNCF Landscape](https://landscape.cncf.io/) - Explore graduated CNCF projects
-  that are generally considered production-ready
+- [CNCF Landscape](https://landscape.cncf.io/) - Graduated CNCF projects
+  considered production-ready
 - [Kubespray](https://kubespray.io/) - Deploy production-ready Kubernetes
   clusters on bare-metal or virtual machines
 - [Argo](https://argoproj.github.io/) - Kubernetes-native continuous delivery
@@ -126,8 +112,8 @@ infrastructure instead of managed cloud services.
 
 ### End-to-end platforms
 
-These tools cover the whole ML lifecycle in a single platform. They are often
-opinionated, so this guide prefers composable tools instead.
+Tools that cover the whole ML lifecycle in one platform. They are often
+opinionated, so this guide prefers composable tools.
 
 - [MLFlow](https://mlflow.org/) - Open-source platform for the machine learning
   lifecycle

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -37,12 +37,16 @@ Alternatives to DVC.
 
 ### Experiment tracking
 
-Alternatives to CML for tracking experiments and reporting metrics in CI/CD
-pipelines.
+Alternatives to CML for tracking experiments and visualizing metrics. CML
+reports results inside CI/CD pipelines, these tools track and visualize
+experiments instead.
 
-- [GuildAi](https://guild.ai/) - Open-source experiment tracking toolkit
-- [Aim](https://aimstack.io/) - Open-source, self-hosted ML experiment tracking
-  tool
+- [Guild AI](https://github.com/guildai/guildai) - Open-source toolkit for
+  running, tracking, and optimizing ML experiments
+- [Aim](https://github.com/aimhubio/aim) - Open-source, self-hosted tool for
+  tracking and visualizing ML experiments
+- [TensorBoard](https://github.com/tensorflow/tensorboard) - Open-source toolkit
+  for visualizing ML experiment metrics and model graphs
 
 ### Model monitoring
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -58,6 +58,17 @@ CI/CD pipelines.
 - [Aim](https://aimstack.io/) - Open-source, self-hosted ML experiment tracking
   tool
 
+### Model monitoring
+
+These are alternatives to Evidently AI for monitoring models in production.
+
+- [NannyML](https://www.nannyml.com/) - Detect model and data drift, including
+  estimated performance degradation, without needing ground truth labels
+- [Deepchecks](https://deepchecks.com/) - Test and validate ML models and data,
+  with a library or self-hosted UI
+- [Seldon Alibi Detect](https://github.com/SeldonIO/alibi-detect) - Algorithms
+  for outlier, adversarial, and drift detection
+
 ### Data annotation
 
 At the moment, Label Studio is the only solution that allows to annotate many

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,9 +24,6 @@ process:
 
 You will go into details about each tool in the following parts of this guide.
 
-<!-- TODO: Add an illustration to display the different tools and their
-purposes? -->
-
 ## Related tools
 
 While this guide concentrates solely on the setup and utilization of the
@@ -77,59 +74,62 @@ at the
 [`awesome-data-labeling`](https://github.com/heartexlabs/awesome-data-labeling)
 Git repository for specific alternatives.
 
-### Model orchestration
+### Pipeline orchestration
 
 These are alternatives to GitHub Actions.
 
-- [GitLab CI](https://about.gitlab.com/topics/ci-cd/) - A complete DevOps platform with built-in CI/CD and container registry
-- [Gitea](https://about.gitea.com/) - A painless self-hosted Git service with
-  built-in CI/CD using GitHub Actions-compatible syntax
-- [Forgejo](https://forgejo.org/) - A self-hosted Git service and soft fork of
+- [GitLab CI](https://about.gitlab.com/topics/ci-cd/) - DevOps platform with
+  built-in CI/CD and container registry
+- [Gitea](https://about.gitea.com/) - Self-hosted Git service with built-in
+  CI/CD using GitHub Actions-compatible syntax
+- [Forgejo](https://forgejo.org/) - Self-hosted Git service and soft fork of
   Gitea with GitHub Actions-compatible workflows
 
-### Model management/deployment
+### Model packaging and serving
 
-These are alternatives to BentoML and Docker.
+These are alternatives to BentoML for packaging and serving models.
 
-- [Kubeflow](https://www.kubeflow.org/) - The Kubeflow project is dedicated to
-  making deployments of machine learning (ML) workflows on Kubernetes simple,
-  portable and scalable
-- [MLEM](https://mlem.ai/) - The open-source tool to simplify your ML model
-  deployments
-- [Cog](https://github.com/replicate/cog) - An open-source tool that lets you
-  package machine learning models in a standard, production-ready container
-- [Podman](https://podman.io/) - A daemonless, open source, Linux native tool
-  designed to make it easy to find, run, build, share and deploy applications
-  using Open Container Initiative containers and images
+- [MLEM](https://mlem.ai/) - Open-source tool to simplify ML model deployments
+- [Cog](https://github.com/replicate/cog) - Package machine learning models in
+  standard, production-ready containers
+- [Seldon Core](https://www.seldon.io/seldon-core) - Open-source platform to
+  deploy ML models on Kubernetes
+- [Kubeflow](https://www.kubeflow.org/) - ML workflows on Kubernetes, including
+  training and serving
+
+### Container tools
+
+These are alternatives to Docker.
+
+- [Podman](https://podman.io/) - Daemonless, open-source tool for running,
+  building, and sharing OCI containers and images
 
 ### Self-hosted / on-premise infrastructure
 
 These tools are useful if you want to run the MLOps stack on your own
 infrastructure instead of managed cloud services.
 
-- [CNCF Landscape](https://landscape.cncf.io/) - Explore graduated CNCF
-  projects that are generally considered production-ready
+- [CNCF Landscape](https://landscape.cncf.io/) - Explore graduated CNCF projects
+  that are generally considered production-ready
 - [Kubespray](https://kubespray.io/) - Deploy production-ready Kubernetes
   clusters on bare-metal or virtual machines
-- [Argo](https://argoproj.github.io/) - Kubernetes-native continuous
-  delivery (Argo CD) and workflow orchestration (Argo Workflows)
+- [Argo](https://argoproj.github.io/) - Kubernetes-native continuous delivery
+  (Argo CD) and workflow orchestration (Argo Workflows)
 - [Harbor](https://goharbor.io/) - Self-hosted container registry with
   vulnerability scanning and RBAC
 - [Distribution Registry](https://distribution.github.io/distribution/) -
   Lightweight local container registry, also known as Docker Registry
-- [Helm](https://helm.sh/) - Package manager for Kubernetes; commonly used
-  to install and manage Argo, registries, and CI runners
-- [Docker Swarm](https://docs.docker.com/engine/swarm/) - Simpler,
-  built-in container orchestration alternative to Kubernetes
+- [Helm](https://helm.sh/) - Package manager for Kubernetes; commonly used to
+  install and manage Argo, registries, and CI runners
+- [Docker Swarm](https://docs.docker.com/engine/swarm/) - Simpler, built-in
+  container orchestration alternative to Kubernetes
 
-### End-to-end
+### End-to-end platforms
 
-These tools can be used to manage the entire lifecycle of the ML experiment.
-These tools were considered at the beginning of this document redaction. But as
-most of the tools are often opinionated and may lack the flexibility needed for
-the scope of this project, they were omitted.
+These tools cover the whole ML lifecycle in a single platform. They are often
+opinionated, so this guide prefers composable tools instead.
 
-- [MLFlow](https://mlflow.org/) - An open source platform for the machine
-  learning lifecycle
-- [MLRun](https://www.mlrun.org/) - An open source framework to orchestrate
-  MLOps from the research stage to production-ready AI applications
+- [MLFlow](https://mlflow.org/) - Open-source platform for the machine learning
+  lifecycle
+- [MLRun](https://www.mlrun.org/) - Open-source framework to orchestrate MLOps
+  from research to production

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,8 @@
 # Tools
 
-This guide uses the following tools:
+The tools used in this guide.
+
+## Core tools
 
 - Code management: [:simple-git: Git](https://git-scm.com/)
 - Package management: [:simple-python: pip](https://pip.pypa.io/) (or


### PR DESCRIPTION
- **Fix venv status chaeck warning leftover**
- **Simplify syllabus opening and align with MLOps lifecycle**
- **Add AGENTS.md file**
- **Clarify main tools list and remove DVC duplication**
- **Rename Monitoring/tracking section to Experiment tracking**
- **Add open-source model monitoring alternatives to Evidently AI**
- **Reorganize deployment categories and tighten tools page wording**
- **Polish tools.md for clarity and concision**
- **Rename tools section to Core tools to avoid repetition**
