### PR TITLE
Landing page polish and no-JS console browser fixes

### DIFF
--- a/docs/assets/javascripts/home.js
+++ b/docs/assets/javascripts/home.js
@@ -121,6 +121,7 @@
     }
 
     layoutBelt();
+    belt.classList.add('is-ready');
     updateBelt();
 
     function onResize() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ home:
   chapters:
     - id: about
       label: Ground control
+      prefix: Prologue
       title: Meet the
       title_highlight: Crew
       body: |
@@ -42,6 +43,7 @@ home:
           url: "https://mlops.swiss-ai-center.ch/presentation/a-guide-to-mlops-presentation.pdf"
     - id: intro
       label: Mission briefing
+      prefix: Introduction
       title: Why this
       title_highlight: "guide?"
       planet: moon
@@ -61,6 +63,7 @@ home:
           path: philosophy/
     - id: part-1
       label: Part 1 — Lift-off
+      prefix: Part 1
       title: Local training &
       title_highlight: model evaluation
       planet: earth
@@ -80,6 +83,7 @@ home:
           path: part-1-local-training-and-evaluation/introduction/
     - id: part-2
       label: Part 2 — Escape velocity
+      prefix: Part 2
       title: Move the model to the
       title_highlight: cloud
       planet: mars
@@ -100,6 +104,7 @@ home:
           path: part-2-move-to-the-cloud/introduction/
     - id: part-3
       label: Part 3 — In orbit
+      prefix: Part 3
       title: Serve &
       title_highlight: deploy
       planet: saturn
@@ -120,6 +125,7 @@ home:
           path: part-3-serve-and-deploy/introduction/
     - id: part-4
       label: Part 4 — Sensor array
+      prefix: Part 4
       title: Monitor &
       title_highlight: maintain
       planet: comet
@@ -141,6 +147,7 @@ home:
           path: part-4-monitor-and-maintain/introduction/
     - id: part-5
       label: Part 5 — Deep space loop
+      prefix: Part 5
       title: Label data &
       title_highlight: retrain
       planet: haumea
@@ -160,6 +167,7 @@ home:
           path: part-5-label-data-and-retrain/introduction/
     - id: reentry
       label: Reentry
+      prefix: Conclusion
       title: Clean up &
       title_highlight: conclude
       planet: capsule

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ home:
           icon: lucide/lightbulb
           path: philosophy/
     - id: part-1
-      label: Part 1 — Lift-off
+      label: Lift-off
       prefix: Part 1
       title: Local training &
       title_highlight: model evaluation
@@ -82,7 +82,7 @@ home:
           icon: lucide/flask-conical
           path: part-1-local-training-and-evaluation/introduction/
     - id: part-2
-      label: Part 2 — Escape velocity
+      label: Escape velocity
       prefix: Part 2
       title: Move the model to the
       title_highlight: cloud
@@ -103,7 +103,7 @@ home:
           icon: lucide/cloud
           path: part-2-move-to-the-cloud/introduction/
     - id: part-3
-      label: Part 3 — In orbit
+      label: In orbit
       prefix: Part 3
       title: Serve &
       title_highlight: deploy
@@ -124,7 +124,7 @@ home:
           icon: lucide/server
           path: part-3-serve-and-deploy/introduction/
     - id: part-4
-      label: Part 4 — Sensor array
+      label: Sensor array
       prefix: Part 4
       title: Monitor &
       title_highlight: maintain
@@ -146,7 +146,7 @@ home:
           icon: lucide/activity
           path: part-4-monitor-and-maintain/introduction/
     - id: part-5
-      label: Part 5 — Deep space loop
+      label: Deep space loop
       prefix: Part 5
       title: Label data &
       title_highlight: retrain

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ home:
         Ground control, reporting for duty. We are the
         <a href="https://www.swiss-ai-center.ch/" class="crew-link" target="_blank" rel="noopener">Swiss AI Center</a>
         crew, building a practical flight plan from machine-learning experiments to production.
-        We selected tools that fit established workflows and teams, with a focus on SMEs.
+        We selected tools that minimize friction for established workflows and teams, with a focus on SMEs.
       actions:
         - type: primary
           text: Next stop

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 template: home.html
-title: MLOps Guide - Complete Tutorial on Machine Learning Operations
-description: Complete MLOps guide covering ML operations tools and best practices - from conventional to modern approaches for deploying ML models in production
+title: MLOps Guide — Complete Tutorial on Machine Learning Operations
+description: Complete MLOps tutorial covering tools and best practices for deploying ML models in production
 hide:
   - navigation
   - toc
@@ -11,8 +11,8 @@ home:
       text: Hands-on tutorial
     title: A Guide to MLOps
     subtitle: |
-      Classify celestial bodies using best practices:
-      a practical journey through local training, the cloud, serving, monitoring, labeling, and retraining.
+      Classify celestial bodies with MLOps best practices:
+      a journey through local training, the cloud, serving, monitoring, labeling, and retraining.
     cta:
       text: Chart the course
       icon: lucide/compass
@@ -26,8 +26,7 @@ home:
         Ground control, reporting for duty. We are the
         <a href="https://www.swiss-ai-center.ch/" class="crew-link" target="_blank" rel="noopener">Swiss AI Center</a>
         crew, building a practical flight plan from machine-learning experiments to production.
-        We have carefully selected the most suitable tools to minimize friction within established
-        workflows and teams, with a particular focus on SMEs.
+        We selected tools that fit established workflows and teams, with a focus on SMEs.
       actions:
         - type: primary
           text: Next stop
@@ -48,9 +47,9 @@ home:
       planet: moon
       body: |
         Building a model is only the beginning. This guide is a step-by-step flight plan
-        that takes you from a notebook experiment to a reproducible, monitored, and
-        continuously-improved ML system. We use concrete tools — DVC, CML, Docker,
-        BentoML, Evidently AI and Label Studio — so you can follow along with real code.
+        from a notebook experiment to a reproducible, monitored, and continuously-improved ML system.
+        We use real tools — DVC, CML, Docker, BentoML, Evidently AI, and Label Studio —
+        so you can follow along with real code.
       actions:
         - type: primary
           text: Next stop
@@ -69,8 +68,7 @@ home:
         Start on solid ground. Move from a Jupyter notebook experiment to clean
         Python scripts, then version your data and code with Git and DVC. Build a
         reproducible prepare-train-evaluate pipeline on your own machine, and use
-        DVC to compare parameters, metrics, and plots so you can see how your
-        model evolves.
+        DVC to track parameters, metrics, and plots as your model evolves.
       actions:
         - type: primary
           text: Next stop
@@ -89,8 +87,8 @@ home:
         When your local machine is no longer enough, move the experiment to the
         cloud. Push your code to GitHub, store data in an S3 bucket with DVC, and
         set up a CI/CD pipeline that reproduces the experiment on every push. Then
-        use CML to publish parameter, metric, and plot comparisons in pull requests
-        so the team can review every change.
+        use CML to publish comparisons of parameters, metrics, and plots in pull
+        requests so the team can review every change.
       actions:
         - type: primary
           text: Next stop
@@ -106,7 +104,7 @@ home:
       title_highlight: deploy
       planet: saturn
       body: |
-        A trained model only creates value when it can serve predictions. Package it
+        A trained model creates value only when it serves predictions. Package it
         with BentoML and expose a local FastAPI endpoint, then containerize it with
         Docker and push the image to a registry. Wire builds and deployments into
         your CI/CD pipeline, roll the model out on Kubernetes, and scale training
@@ -128,10 +126,10 @@ home:
       body: |
         A model in production needs watching. Stream prediction logs to S3, deploy
         an Evidently AI dashboard on Kubernetes to compare live data against your
-        training reference, and open drift reports as GitHub issues when things
-        shift. Use those signals to trigger retraining workflows or roll back to a
-        previous model version by redeploying its container image, with Git and DVC
-        as the reproducible source of truth.
+        training reference, and open drift reports as GitHub issues when data drifts.
+        Use those signals to trigger retraining workflows or roll back to a previous
+        model version by redeploying its container image, with Git and DVC as the
+        reproducible source of truth.
       actions:
         - type: primary
           text: Next stop
@@ -149,8 +147,8 @@ home:
       body: |
         Production data changes. Close the feedback loop with Label Studio: let
         your model suggest labels through the FastAPI endpoint, review and correct
-        edge cases, then merge the refined annotations back and retrain with DVC.
-        A better model makes the next round of labeling faster and more accurate.
+        edge cases, then merge the refined annotations and retrain with DVC. A
+        better model makes the next round of labeling faster and more accurate.
       actions:
         - type: primary
           text: Next stop
@@ -169,9 +167,8 @@ home:
       body: |
         Finish the journey by cleaning up everything you created. Delete cloud
         resources, remove the GitHub repository and access tokens, wipe your local
-        environment, and take a moment to review what you have built. A proper
-        cleanup avoids unexpected costs. A safe landing is the final stage of a
-        successful mission.
+        environment, and review what you built. A proper cleanup avoids unexpected
+        costs. A safe landing is the final stage of a successful mission.
       actions:
         - type: primary
           text: Launch pad
@@ -185,7 +182,7 @@ home:
     title: Ready for
     title_highlight: launch?
     subtitle: |
-      The guide is open source and built to be followed hands-on.
+      The guide is open source and designed to be followed hands-on.
       Pick a chapter, launch your terminal, and start shipping ML systems.
     cta:
       text: Start the journey

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -291,7 +291,6 @@
   .story-main {
     position: relative;
     z-index: 3;
-    counter-reset: chapter;
   }
 
   /* Chapter sections */
@@ -356,16 +355,7 @@
     text-transform: uppercase;
     letter-spacing: -0.01em;
   }
-  .chapter-title::before {
-    counter-increment: chapter;
-    content: "SEC " counter(chapter, decimal-leading-zero) " — ";
-    display: block;
-    font-family: var(--tech-mono);
-    font-size: 0.45em;
-    color: var(--accent);
-    letter-spacing: 0.12em;
-    margin-bottom: 0.35rem;
-  }
+
   .chapter-title span {
     color: var(--accent);
   }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -524,7 +524,8 @@
     .finale-launchpad { display: none; }
   }
 
-  /* Light theme overrides */
+  /* Light theme overrides: skip them for no-JS clients that prefer dark mode */
+  @media not ((scripting: none) and (prefers-color-scheme: dark)) {
   body[data-md-color-scheme="default"] {
     background: #f7f8fc;
   }
@@ -650,6 +651,7 @@
   }
   body[data-md-color-scheme="default"] .story-finale .finale-logo {
     filter: none;
+  }
   }
 </style>
 {% endblock %}

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -142,6 +142,11 @@
     left: 0;
     width: 100vw;
     will-change: transform;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+  .belt-track.is-ready {
+    opacity: 1;
   }
   .belt-planet {
     position: absolute;

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -81,9 +81,10 @@
     stroke: currentcolor;
   }
 
-  /* Decorative inline SVG icons are redundant in text-only / no-JS clients */
+  /* Decorative inline SVG icons and planet belt are redundant in text-only / no-JS clients */
   @media (scripting: none) {
-    .twemoji {
+    .twemoji,
+    .planet-belt {
       display: none;
     }
   }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -363,6 +363,16 @@
     text-transform: uppercase;
     letter-spacing: -0.01em;
   }
+  .chapter-prefix {
+    display: block;
+    font-family: var(--tech-mono);
+    font-size: 0.45em;
+    letter-spacing: 0.12em;
+    margin-bottom: 0.35rem;
+  }
+  .chapter-prefix::after {
+    content: " —";
+  }
 
   .chapter-title span {
     color: var(--accent);
@@ -722,7 +732,7 @@
   <section class="story-chapter{% if chapter.reentry %} reentry{% endif %}" id="section-{{ chapter.id }}"{% if chapter.planet %} data-planet="{{ chapter.planet }}"{% endif %}>
     <article class="chapter-card reveal">
       <div class="chapter-label">{{ chapter.label }}</div>
-      <h2 class="chapter-title">{{ chapter.title }}{% if chapter.title_highlight %} <span>{{ chapter.title_highlight }}</span>{% endif %}</h2>
+      <h2 class="chapter-title">{% if chapter.prefix %}<span class="chapter-prefix">{{ chapter.prefix }}</span>{% endif %}{{ chapter.title }}{% if chapter.title_highlight %} <span>{{ chapter.title_highlight }}</span>{% endif %}</h2>
       <p>
         {{- chapter.body | safe -}}
       </p>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -81,6 +81,13 @@
     stroke: currentcolor;
   }
 
+  /* Decorative inline SVG icons are redundant in text-only / no-JS clients */
+  @media (scripting: none) {
+    .twemoji {
+      display: none;
+    }
+  }
+
   /* Starfield */
   .starfield {
     position: fixed;
@@ -698,7 +705,7 @@
     {{- home.hero.subtitle -}}
   </p>
   <a href="{{ home.hero.cta.anchor }}" class="hero-cta">
-    <span class="twemoji">{% include ".icons/" ~ home.hero.cta.icon ~ ".svg" %}</span>
+    <span class="twemoji" aria-hidden="true">{% include ".icons/" ~ home.hero.cta.icon ~ ".svg" %}</span>
     {{ home.hero.cta.text }}
   </a>
 
@@ -722,7 +729,7 @@
         {% for action in chapter.actions %}
         {% if action.type == "pdf" %}
         <a href="{{ action.url }}" class="pdf-link">
-          <span class="twemoji">{% include ".icons/" ~ action.icon ~ ".svg" %}</span>
+          <span class="twemoji" aria-hidden="true">{% include ".icons/" ~ action.icon ~ ".svg" %}</span>
           {{ action.text }}
         </a>
         {% else %}
@@ -735,7 +742,7 @@
             {{ action.url }}
           {%- endif -%}
         " class="chapter-link {{ action.type }}{% if action.type == 'primary' %} next-section{% endif %}">
-          <span class="twemoji">{% include ".icons/" ~ action.icon ~ ".svg" %}</span>
+          <span class="twemoji" aria-hidden="true">{% include ".icons/" ~ action.icon ~ ".svg" %}</span>
           {{ action.text }}
         </a>
         {% endif %}
@@ -753,7 +760,7 @@
     {{- home.finale.subtitle -}}
   </p>
   <a href="{{ home.finale.cta.path | url }}" class="hero-cta">
-    <span class="twemoji">{% include ".icons/" ~ home.finale.cta.icon ~ ".svg" %}</span>
+    <span class="twemoji" aria-hidden="true">{% include ".icons/" ~ home.finale.cta.icon ~ ".svg" %}</span>
     {{ home.finale.cta.text }}
   </a>
 


### PR DESCRIPTION
- **Remove auto-generated SEC numbering from landing page chapter titles**
- **Polish landing page prose in docs/index.md**
- **Hide decorative inline SVG icons in no-JS / console browsers**
- **Hide decorative planet belt in no-JS / console browsers**
- **Restore stylized chapter prefixes from docs/index.md**
- **Drop Part N from landing-page chapter labels**
- **Prevent planet belt flash before JavaScript positions it**
- **Respect prefers-color-scheme for no-JS landing-page theme**
