### PR TITLE
Fix dvc.lock autoupdate triggering training workflow again

### DIFF
--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -770,22 +770,18 @@ jobs:
 
 !!! tip "Prevent the auto-commit from re-triggering the workflow"
 
-    The commit message for the automatically committed `dvc.lock` file includes
-    `[skip ci]`. This tells GitHub Actions to skip the workflow run for that
-    specific commit, so pushing the updated `dvc.lock` back to the pull request
-    branch does not start a new `train-and-report` run on the self-hosted runner.
-
-    Without this, the auto-commit would create a new `pull_request` event and re-run
-    the whole workflow, wasting compute resources on a result that has already been
-    validated.
+    Without `[skip ci]`, pushing the updated `dvc.lock` back to the pull request
+    branch would create a new `pull_request` event and re-run the whole
+    `train-and-report` job on the self-hosted runner, wasting compute resources on a
+    result that has already been validated.
 
 Here, the following should be noted:
 
 * the `train-report` job runs on the self-hosted runner on pull requests. It
   trains the model and DVC pushes the trained model to the remote bucket.
 * the updated `dvc.lock` file is automatically committed back to the pull
-  request branch, so contributors do not need to run `dvc repro` locally before
-  pushing model changes.
+  request branch with `[skip ci]` in the commit message to prevent the workflow
+  from re-running.
 * the `publish-and-deploy` runs on the main runner when merging pull requests.
   It retrieves the model with DVC, containerizes then deploys the model artifact.
 

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -777,7 +777,7 @@ jobs:
 
 Here, the following should be noted:
 
-* the `train-report` job runs on the self-hosted runner on pull requests. It
+* the `train-and-report` job runs on the self-hosted runner on pull requests. It
   trains the model and DVC pushes the trained model to the remote bucket.
 * the updated `dvc.lock` file is automatically committed back to the pull
   request branch with `[skip ci]` in the commit message to prevent the workflow

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -770,10 +770,10 @@ jobs:
 
 !!! tip "Prevent the auto-commit from re-triggering the workflow"
 
-    Without `[skip ci]`, pushing the updated `dvc.lock` back to the pull request
-    branch would create a new `pull_request` event and re-run the whole
-    `train-and-report` job on the self-hosted runner, wasting compute resources on a
-    result that has already been validated.
+    Without `[skip ci]` in the commit message, pushing the updated `dvc.lock` back
+    to the pull request branch would create a new `pull_request` event and re-run
+    the whole `train-and-report` job on the self-hosted runner, wasting compute
+    resources on a result that has already been validated.
 
 Here, the following should be noted:
 

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -659,7 +659,7 @@ jobs:
       - name: Commit changes in dvc.lock
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: Commit changes in dvc.lock
+          commit_message: Commit changes in dvc.lock [skip ci]
           file_pattern: dvc.lock
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -768,6 +768,17 @@ jobs:
             -f kubernetes/service.yaml
 ```
 
+!!! tip "Prevent the auto-commit from re-triggering the workflow"
+
+    The commit message for the automatically committed `dvc.lock` file includes
+    `[skip ci]`. This tells GitHub Actions to skip the workflow run for that
+    specific commit, so pushing the updated `dvc.lock` back to the pull request
+    branch does not start a new `train-and-report` run on the self-hosted runner.
+
+    Without this, the auto-commit would create a new `pull_request` event and re-run
+    the whole workflow, wasting compute resources on a result that has already been
+    validated.
+
 Here, the following should be noted:
 
 * the `train-report` job runs on the self-hosted runner on pull requests. It
@@ -817,7 +828,7 @@ index b15a68f..5a8d863 100644
 +      - name: Commit changes in dvc.lock
 +        uses: stefanzweifel/git-auto-commit-action@v7
 +        with:
-+          commit_message: Commit changes in dvc.lock
++          commit_message: Commit changes in dvc.lock [skip ci]
 +          file_pattern: dvc.lock
 +      - name: Setup Node
 +        uses: actions/setup-node@v6
@@ -997,6 +1008,7 @@ Highly inspired by:
 - [_Adding self-hosted runners_ - GitHub docs](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners)
 - [_GitHub Actions self-hosted runners on Google Cloud_ - github.blog](https://github.blog/news-insights/product-news/github-actions-self-hosted-runners-on-google-cloud/)
 - [_Self-hosted runner security_ - GitHubdocs](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
+- [_Skip workflow runs_ - GitHub docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs)
 - [_Security for self-managed runners_ - GitLab docs](https://docs.gitlab.com/runner/security/)
 - [_Install kubectl and configure cluster access_ - cloud.google.com](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)
 - [_Deploying to Google Kubernetes Engine_ - GitHub docs](https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-google-kubernetes-engine)

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -783,6 +783,9 @@ Here, the following should be noted:
 
 * the `train-report` job runs on the self-hosted runner on pull requests. It
   trains the model and DVC pushes the trained model to the remote bucket.
+* the updated `dvc.lock` file is automatically committed back to the pull
+  request branch, so contributors do not need to run `dvc repro` locally before
+  pushing model changes.
 * the `publish-and-deploy` runs on the main runner when merging pull requests.
   It retrieves the model with DVC, containerizes then deploys the model artifact.
 

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -501,7 +501,7 @@ jobs:
       - name: Commit changes in dvc.lock
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: Commit changes in dvc.lock
+          commit_message: Commit changes in dvc.lock [skip ci]
           file_pattern: dvc.lock
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
- **Add [skip ci] to dvc.lock auto-commit in self-hosted runner chapter**
- **Mention dvc.lock auto-commit in workflow summary**
- **Trim [skip ci] tip and clarify dvc.lock auto-commit bullet**
